### PR TITLE
Update image crate to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 byteorder = "0.3.9"
-image = "0.3.11"
+image = "0.10"
 chrono = "0.2"
 itertools = "0.3"
 clap = "*"


### PR DESCRIPTION
Hi!

I read [your tweet](https://twitter.com/locks/status/763800114066513921) a couple of minutes ago and decided to investigate what was the issue.

The compilation issue was caused by an old png crate version which image 0.3.11 depended on. Updating the image dependency to the latest minor version, 0.10, fixed the issue.
